### PR TITLE
set default user to ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ ADD	. /var/lib/tsuru/base
 RUN set -ex; \
     /var/lib/tsuru/base/install;  \
     rm -rf /var/lib/apt/lists/*
+USER ubuntu


### PR DESCRIPTION
This was already expected when using the platform, making it explict
here may help simplifing tsuru as it will no longer need to set the user
on each container creation