### PR TITLE
install:  Remove .bash_logout script

### DIFF
--- a/install
+++ b/install
@@ -11,6 +11,9 @@ mkdir -p /home/application
 useradd -m ${USER} -s /bin/bash
 chown ${USER}:${USER} /home/application
 
+# Remove logout script to avoid errors when running clear_console without a terminal
+rm -f ${HOME}/.bash_logout
+
 cp ${SOURCE_DIR}/base/apt.conf.d/local /etc/apt/apt.conf.d/local
 buildDeps='curl sudo jq rsync netcat-openbsd net-tools telnet vim-tiny lsof ca-certificates'
 apt-get update


### PR DESCRIPTION
When the deploy script is run with `bash -l`, if it calls `exit 0`, a chain reaction is triggered:

- bash calls `.bash_logout` script after the `exit` call
- `.bash_logout` calls `clear_console -q`
- `clear_console` fails with exit code 1 (`terminal is not a console`), but the error message isn't shown, because of the `-q` flag
- the deploy script ends up silently returning 1, which makes the deploy fail

Currently this happens in the Go platform, when you try to deploy an app without sending any *.go files.

There are two solutions to this problem: removing the `-l` flag from every platform deploy script, or remove the `.bash_logout` file, which is easier and safer.

This fixes #5 , and should also fix this test from deploy agent: https://github.com/tsuru/deploy-agent/commit/1e7ce7200f1e768c8e9958114fe49859a14c4746