### PR TITLE
Allow one-line-style format

### DIFF
--- a/rc/config
+++ b/rc/config
@@ -30,6 +30,8 @@ function add_repository() {
 		ppa=$(echo $1 | awk -F : '{print $2}')
 		repository="deb http://ppa.launchpad.net/${ppa}/ubuntu ${UBUNTU_RELEASE} main"
 		get_ppa_key $ppa
+	elif [[ "$*" =~ ^deb(-src)?.+ ]]; then
+		repository=$*
 	else
 		repository=$1
 		if [[ "$2" =~ ^0x.+ ]]; then

--- a/rc/os_dependencies
+++ b/rc/os_dependencies
@@ -7,9 +7,9 @@
 function os_dependencies() {
     if [ -f ${CURRENT_DIR}/repositories.apt ]; then
         source /var/lib/tsuru/base/rc/config
-        for repo in `cat ${CURRENT_DIR}/repositories.apt`; do
+        while read repo ; do
             add_repository ${repo}
-        done
+        done < ${CURRENT_DIR}/repositories.apt
     fi
     if [ -f ${CURRENT_DIR}/requirements.apt ]; then
         set +e


### PR DESCRIPTION
This fix allow one-line-style entries using the deb and deb-src types:
           deb [ option1=value1 option2=value2 ] uri suite [component1] [component2] [...]
           deb-src [ option1=value1 option2=value2 ] uri suite [component1] [component2] [...]