### PR TITLE
feat: hash comments on requirements and repositories

### DIFF
--- a/14.04/rc/os_dependencies
+++ b/14.04/rc/os_dependencies
@@ -4,21 +4,28 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+function cat_without_hash_comments() {
+  # removes all '#' and all characters afterwards
+  # and empty lines in case there where lines that start with '#'
+  (sed "s/#.*$//g" | sed "/^[[:space:]]*$/d") < "$1"
+}
+
 function os_dependencies() {
     if [ -f ${CURRENT_DIR}/repositories.apt ]; then
         source /var/lib/tsuru/base/rc/config
         while read repo ; do
             add_repository ${repo}
-        done < ${CURRENT_DIR}/repositories.apt
+        done < <(cat_without_hash_comments "${CURRENT_DIR}/repositories.apt")
     fi
     if [ -f ${CURRENT_DIR}/requirements.apt ]; then
         set +e
-        sudo -E apt-get install $(cat ${CURRENT_DIR}/requirements.apt) -y --force-yes --no-install-recommends
+        requirements_without_comments="$(cat_without_hash_comments ${CURRENT_DIR/requirements.apt})"
+        sudo -E apt-get install $requirements_without_comments -y --force-yes --no-install-recommends
         status=$?
         set -e
         if [ ${status} != 0 ]; then
             sudo apt-get update
-            sudo -E apt-get install $(cat ${CURRENT_DIR}/requirements.apt) -y --force-yes --no-install-recommends
+            sudo -E apt-get install $requirements_without_comments -y --force-yes --no-install-recommends
         fi
     fi
 }

--- a/18.04/rc/os_dependencies
+++ b/18.04/rc/os_dependencies
@@ -4,21 +4,28 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+function cat_without_hash_comments() {
+  # removes all '#' and all characters afterwards
+  # and empty lines in case there where lines that start with '#'
+  (sed "s/#.*$//g" | sed "/^[[:space:]]*$/d") < "$1"
+}
+
 function os_dependencies() {
     if [ -f ${CURRENT_DIR}/repositories.apt ]; then
         source /var/lib/tsuru/base/rc/config
         while read repo ; do
             add_repository ${repo}
-        done < ${CURRENT_DIR}/repositories.apt
+        done < <(cat_without_hash_comments "${CURRENT_DIR}/repositories.apt")
     fi
     if [ -f ${CURRENT_DIR}/requirements.apt ]; then
         set +e
-        sudo -E apt-get install $(cat ${CURRENT_DIR}/requirements.apt) -y --force-yes --no-install-recommends
+        requirements_without_comments="$(cat_without_hash_comments ${CURRENT_DIR/requirements.apt})"
+        sudo -E apt-get install $requirements_without_comments -y --force-yes --no-install-recommends
         status=$?
         set -e
         if [ ${status} != 0 ]; then
             sudo apt-get update
-            sudo -E apt-get install $(cat ${CURRENT_DIR}/requirements.apt) -y --force-yes --no-install-recommends
+            sudo -E apt-get install $requirements_without_comments -y --force-yes --no-install-recommends
         fi
     fi
 }


### PR DESCRIPTION
This PR adds the possibility for comments on `requirements.apt` and `repositories.apt` files. It supports both whole line and inline comments

Example:

```
# This is a comment in the file requirements.apt
cron # this is a comment also
cowsay 
#and so is this
```

Got the idea after a comment on slack from @magnotorres 